### PR TITLE
[01/19] ROT13

### DIFF
--- a/Baekjoon/11655_ROT13.swift
+++ b/Baekjoon/11655_ROT13.swift
@@ -1,0 +1,32 @@
+//1. 문자열을 입력받아 Character 배열로 만든다.
+let inputData = readLine()!.map { $0 }
+var result = ""
+
+//2. Character배열을 순회한다.
+for char in inputData {
+    result += rot13(char)
+}
+print(result)
+
+func rot13(_ char: Character) -> String {
+    
+    var asciiValue = Int(char.asciiValue!)
+    
+    //3. 만약 알파벳이라면, 13을 밀어서 출력한다. (Unicode 활용)
+    switch asciiValue {
+    case 65...90: // 대문자
+        asciiValue += 13
+        if asciiValue > 90 {
+            asciiValue = asciiValue % 90 + 64
+        }
+    case 97...122: // 소문자
+        asciiValue += 13
+        if asciiValue > 122 {
+            asciiValue = asciiValue % 122 + 96
+        }
+    default:
+        break
+    }
+    
+    return UnicodeScalar(asciiValue)!.description
+}


### PR DESCRIPTION
# [11655 ROT13](https://www.acmicpc.net/problem/11655)

### 접근 방법

<aside>
💡 간단한 구현문제이다.
알파벳이라면 13을 밀고, 알파벳이 아닐 땐 그대로 출력한다.

</aside>

ROT13은 카이사르 암호의 일종으로 영어 알파벳을 13글자씩 밀어서 만든다.

예를 들어, "Baekjoon Online Judge"를 ROT13으로 암호화하면 "Onrxwbba Bayvar Whqtr"가 된다. ROT13으로 암호화한 내용을 원래 내용으로 바꾸려면 암호화한 문자열을 다시 ROT13하면 된다. 앞에서 암호화한 문자열 "Onrxwbba Bayvar Whqtr"에 다시 ROT13을 적용하면 "Baekjoon Online Judge"가 된다.

ROT13은 알파벳 대문자와 소문자에만 적용할 수 있다. 알파벳이 아닌 글자는 원래 글자 그대로 남아 있어야 한다. 예를 들어, "One is 1"을 ROT13으로 암호화하면 "Bar vf 1"이 된다.

문자열이 주어졌을 때, "ROT13"으로 암호화한 다음 출력하는 프로그램을 작성하시오.

### 알고리즘

1. 문자열을 입력받아 Character 배열로 만든다.
2. Character배열을 순회한다.
3. 만약 알파벳이라면, 13을 밀어서 출력한다. (Unicode 활용)
4. 알파벳이 아니라면 그대로 둔다.

### 코드

```swift
//1. 문자열을 입력받아 Character 배열로 만든다.
let inputData = readLine()!.map { $0 }
var result = ""

//2. Character배열을 순회한다.
for char in inputData {
    result += rot13(char)
}
print(result)

func rot13(_ char: Character) -> String {
    
    var asciiValue = Int(char.asciiValue!)
    
    //3. 만약 알파벳이라면, 13을 밀어서 출력한다. (Unicode 활용)
    switch asciiValue {
    case 65...90: // 대문자
        asciiValue += 13
        if asciiValue > 90 {
            asciiValue = asciiValue % 90 + 64
        }
    case 97...122: // 소문자
        asciiValue += 13
        if asciiValue > 122 {
            asciiValue = asciiValue % 122 + 96
        }
    default:
        break
    }
    
    return UnicodeScalar(asciiValue)!.description
}
```

### 결과

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/1a149aa8-696f-41ad-aece-d0b2ea3f4002/Untitled.png)

### 참고한 부분

[[Apple Developer Documentation](https://developer.apple.com/documentation/swift/character/unicodescalars)](https://developer.apple.com/documentation/swift/character/unicodescalars)

.isAlpha는 Python 내장함수였던 것 같다. 

Swift에서 알파벳인지 확인할 수 있는 방법? 
